### PR TITLE
Change Python version from 3.12 to 3.11 and update setuptools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,12 @@ jobs:
       - uses: actions/configure-pages@v3
       - uses: typst-community/setup-typst@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+        with:        
+          python-version: '3.11'
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install --upgrade pip setuptools==65.7.0
           pip install -r requirements.txt
 
       - name: Build HTML


### PR DESCRIPTION
We needed to update the python version and the setuptools version to fix building the book. Otherwise, the book build and notebook compilation will result in an error.